### PR TITLE
Fix for issue with old version of read-file-stdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commander": "~2.1.0",
     "node-watch": "0.3.4",
     "pad-component": "0.0.1",
-    "read-file-stdin": "0.0.3",
+    "read-file-stdin": "^0.2.0",
     "rework": "^1.0.0",
     "rework-suit": "^4.0.0",
     "write-file-stdout": "0.0.2"


### PR DESCRIPTION
We have been using Suit CSS Preprocessor in a project that must be built behind a proxy with no connection to github. Currently version 0.0.3 of read-file-std-in itself uses visionmedia/node-concat-stream from github, not npm. This pull request updates that dependency to the latest and resolves this issue.

I have run the tests and they all still pass. 

Please let me know if there is anything else I can do to get this merged.