### PR TITLE
Fix issue with no options being passed to bemLint and reporter

### DIFF
--- a/test/error.config.json
+++ b/test/error.config.json
@@ -1,0 +1,6 @@
+{
+  "postcss-reporter": {
+    "throwError": true,
+    "plugins": ["postcss-bem-linter"]
+  }
+}

--- a/test/fixtures/error.css
+++ b/test/fixtures/error.css
@@ -1,0 +1,3 @@
+/** @define Component **/
+
+.component {}

--- a/test/fixtures/import-error.css
+++ b/test/fixtures/import-error.css
@@ -1,0 +1,1 @@
+@import "./error.css"

--- a/test/test.js
+++ b/test/test.js
@@ -29,12 +29,18 @@ describe('suitcss', function () {
 
     beforeEach(function() {
       mergeOptions = suitcss.__get__('mergeOptions');
-      defaults = suitcss.__get__('defaults');
     });
 
     it('should use default options when nothing is passed', function() {
-      expect(mergeOptions({})).to.eql(defaults);
-      expect(mergeOptions()).to.eql(defaults);
+      var keys = [
+        'minify',
+        'use',
+        'postcss-import',
+        'postcss-reporter',
+        'cssnano'
+      ];
+      expect(mergeOptions({})).to.have.keys(keys);
+      expect(mergeOptions()).to.have.keys(keys);
     });
 
     it('should allow an import root to be set', function() {
@@ -67,7 +73,6 @@ describe('suitcss', function () {
         'postcss-reporter'
       ]);
       expect(opts.autoprefixer).to.eql(autoprefixer);
-      expect(opts['postcss-reporter']).to.eql(defaults['postcss-reporter']);
       expect(opts['postcss-import'].root).to.equal('test/root');
     });
   });
@@ -163,6 +168,15 @@ describe('cli', function () {
       var res = read('fixtures/cli/output');
       var expected = read('fixtures/config.out');
       expect(res).to.equal(expected);
+      done();
+    });
+  });
+
+  it('should output an error to stderr on conformance failure when throwError is set', function(done) {
+    exec('bin/suitcss -i test/fixtures -c test/error.config.json test/fixtures/import-error.css test/fixtures/cli/output.css', function (err, stdout, stderr) {
+      expect(err).to.be.an('error');
+      expect(err.code).to.equal(1);
+      expect(stderr).to.contain('postcss-reporter: warnings or errors were found');
       done();
     });
   });


### PR DESCRIPTION
This moves the `transform` callback into a function that is returned with access to the current merged options in a closure. Ensures that `bem-linter` and `reporter` get any options.

Added a test where it throws an error on conformance failure. This is what I expect will be a common use to fail builds. Will be useful for our own `npm test` in the future.