### PR TITLE
Add ability to manipulate CSS before linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compiles CSS packages with:
 * [postcss-custom-media](https://github.com/postcss/postcss-custom-media)
 * [autoprefixer](https://github.com/postcss/autoprefixer)
 
-In addition each imported file is linted with [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter) and minification is provided by [cssnano](http://cssnano.co/).
+Each imported file is linted with [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter) and minification is provided by [cssnano](http://cssnano.co/). Additional plugins can be added via the configuration options.
 
 ## Installation
 
@@ -64,7 +64,74 @@ Examples:
   $ cat input.css | suitcss | grep background-color
 ```
 
-### Configuration
+### Node.js
+
+Returns a [PostCSS promise](https://github.com/postcss/postcss/blob/master/docs/api.md#lazyresult-class)
+
+```js
+var preprocessor = require('suitcss-preprocessor');
+var fs = require('fs');
+
+var css = fs.readFileSync('src/components/index.css', 'utf8');
+
+preprocessor(css, {
+  root: 'path/to/css',
+  minify: true,
+}).then(function(result) {
+  fs.writeFileSync('build/bundle.css', result.css);
+});
+```
+
+#### Options
+
+##### `root`
+
+* Type: `String`
+* Default: `process.cwd()`
+
+Where to resolve imports from. Passed to [`postcss-import`](https://github.com/postcss/postcss-import/blob/master/README.md#root).
+
+##### `minify`
+
+* Type: `Boolean`
+* Default: `false`
+
+If set to `true` then the output is minified by [`cssnano`](http://cssnano.co/).
+
+##### `beforeLint`
+
+* Type: `Function`
+* Default: `false`
+
+Called with the imported CSS before it's passed to `postcss-bem-linter`. This allows you to transform the CSS first and it must return the css string.
+
+Third paramater is the options object containing any PostCSS configuration you may need.
+
+```js
+{
+  beforeLint(css, filename, options) {
+    // Do something to the imported css
+    return css;
+  }
+}
+```
+
+##### `config`
+
+* Type: `Object`
+* Default: [various](https://github.com/suitcss/preprocessor/blob/master/lib/index.js#L23)
+
+A list of plugins and their options that are passed to PostCSS. This can be used to add new plugins and/or configure existing ones.
+
+```js
+config: {
+  use: ['stylelint', 'postcss-property-lookup'],
+  autoprefixer: { browsers: ['> 1%', 'IE 7'], cascade: false },
+  'postcss-calc': { preserve: true }
+}
+```
+
+### Plugin configuration
 
 Creating a configuration file allows options to be passed to the individual PostCSS plugins. It can be passed to the `suitcss` CLI via the `-c` flag and can be either JavaScript or JSON
 
@@ -90,7 +157,7 @@ Options are merged recursively with the defaults. For example, adding new plugin
 
 By default the preprocessor uses all necessary plugins to build SUIT components. However additional plugins can be installed into a project and then added to the `use` array.
 
-This **will not** work with the preprocessor installed globally. Instead rely on the convenience of `npm run <script>`
+**Note**: This will not work with the preprocessor installed globally. Instead rely on the convenience of `npm run <script>`
 
 ```js
 module.exports = {
@@ -152,29 +219,6 @@ var result = [
   'autoprefixer',
   'postcss-reporter'
 ];
-```
-
-### Node.js
-
-Returns a [PostCSS promise](https://github.com/postcss/postcss/blob/master/docs/api.md#lazyresult-class)
-
-```js
-var preprocessor = require('suitcss-preprocessor');
-var fs = require('fs');
-
-var css = fs.readFileSync('src/components/index.css', 'utf8');
-
-preprocessor(css, {
-  root: 'path/to/css',
-  minify: true,
-  config: {
-    use: ['postcss-property-lookup'],
-    autoprefixer: { browsers: ['> 1%', 'IE 7'], cascade: false },
-    'postcss-calc': { preserve: true }
-  }
-}).then(function(result) {
-  fs.writeFileSync('build/bundle.css', result.css);
-});
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Examples:
   # configure the import root directory:
   $ suitcss --import-root src/css input.css output.css
 
-  # watch the input file for changes:
+  # watch the input file and imports for changes:
   $ suitcss --watch input.css output.css
 
   # configure postcss plugins with a config file:

--- a/bin/suitcss
+++ b/bin/suitcss
@@ -37,7 +37,7 @@ program.on('--help', function () {
   console.log('    # configure the import root directory:');
   console.log('    $ suitcss --import-root src/css input.css output.css');
   console.log();
-  console.log('    # watch the input file for changes:');
+  console.log('    # watch the input file and imports for changes:');
   console.log('    $ suitcss --watch input.css output.css');
   console.log();
   console.log('    # configure postcss plugins with a config file:');

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,15 @@ function mergeOptions(options) {
   // Set some core options
   merged.minify = options.minify;
   merged['postcss-import'].root = options.root;
-  merged['postcss-import'].transform = lintImportedFiles(merged);
+
+  // Call beforeLint function and pass processed css to bem-linter
+  var beforeLint = options.beforeLint;
+  merged['postcss-import'].transform = function(css, filename) {
+    if (typeof beforeLint === 'function') {
+      css = beforeLint(css, filename, merged);
+    }
+    return lintImportedFiles(merged)(css, filename);
+  };
 
   // Allow additional plugins to be merged with the defaults
   // but remove any duplicates so that it respects the new order

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,10 +64,6 @@ var defaults = {
  */
 
 function preprocessor(css, options) {
-  if (typeof css !== 'string') {
-    throw new Error('suitcss-preprocessor: did not receive a String');
-  }
-
   options = mergeOptions(options);
 
   var plugins = options.use.map(function (p) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = preprocessor;
  */
 
 var defaults = {
-  minify: undefined,
+  minify: false,
   use: [
     'postcss-import',
     'postcss-custom-properties',
@@ -31,7 +31,6 @@ var defaults = {
     'postcss-reporter'
   ],
   'postcss-import': {
-    root: undefined,
     onImport: function(imported) {
       // Update the watch task with the list of imported files
       if (typeof global.watchCSS === 'function') {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
     "postcss-property-lookup": "^1.1.4",
-    "rewire": "^2.5.0"
+    "rewire": "^2.5.0",
+    "sinon": "^1.17.2"
   },
   "scripts": {
     "test": "mocha --reporter spec --slow 400",

--- a/test/test.js
+++ b/test/test.js
@@ -19,9 +19,8 @@ describe('suitcss', function () {
     });
   });
 
-  it('should throw if css is not a string', function() {
-    expect(function() {suitcss(null);}).to.throw(Error);
-    expect(function() {suitcss({});}).to.throw(Error);
+  it('should handle invalid input', function() {
+    expect(function() {suitcss(null);}).to.throw(TypeError);
   });
 
   describe('using options', function() {


### PR DESCRIPTION
Another small change, but one that has come from me trying to use the preprocessor on a couple of projects.

It solves the issue of manipulating the CSS before it gets to the linter. An example of this is using `postcss-nested`. It needs to run on each file _before_ it gets to the bem-linter otherwise it would fail.

A `beforeLint` option is now available which allows the user to return manipulated CSS to the bem-linter.

I've also improved the documentation further.