### PR TITLE
Switch to postcss-easy-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ various [PostCSS](https://github.com/postcss/postcss) plugins.
 
 Compiles CSS packages with:
 
-* [postcss-import](https://github.com/postcss/postcss-import)
+* [postcss-easy-import](https://github.com/TrySound/postcss-easy-import)
 * [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties)
 * [postcss-calc](https://github.com/postcss/postcss-calc)
 * [postcss-custom-media](https://github.com/postcss/postcss-custom-media)
@@ -258,7 +258,7 @@ If duplicate plugins are used they will be removed, but the new order will be re
 ```js
 // Default order
 var defaults = [
-  'postcss-import',
+  'postcss-easy-import',
   'postcss-custom-properties',
   'postcss-calc',
   'postcss-custom-media',
@@ -277,7 +277,7 @@ module.exports = {
 };
 
 var result = [
-  'postcss-import',
+  'postcss-easy-import',
   'postcss-custom-properties',
   'postcss-custom-media',
   'postcss-at2x',

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,14 +24,14 @@ var defaults = {
   minify: false,
   lint: false,
   use: [
-    'postcss-import',
+    'postcss-easy-import',
     'postcss-custom-properties',
     'postcss-calc',
     'postcss-custom-media',
     'autoprefixer',
     'postcss-reporter'
   ],
-  'postcss-import': {
+  'postcss-easy-import': {
     onImport: function(imported) {
       // Update the watch task with the list of imported files
       if (typeof global.watchCSS === 'function') {
@@ -92,12 +92,12 @@ function mergeOptions(options) {
 
   // Set some core options
   if (merged.root) {
-    merged['postcss-import'].root = merged.root;
+    merged['postcss-easy-import'].root = merged.root;
   }
 
   // Call beforeLint function and pass processed css to bem-linter
   var beforeLint = merged.beforeLint;
-  merged['postcss-import'].transform = function(css, filename) {
+  merged['postcss-easy-import'].transform = function(css, filename) {
     if (typeof beforeLint === 'function') {
       css = beforeLint(css, filename, merged);
     }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "postcss-calc": "^5.0.0",
     "postcss-custom-media": "^5.0.0",
     "postcss-custom-properties": "^5.0.0",
+    "postcss-easy-import": "^1.0.1",
     "postcss-import": "^8.0.2",
     "postcss-reporter": "^1.3.0",
     "read-file-stdin": "^0.2.1",
-    "stylelint": "^5.0.1"
+    "stylelint": "^5.3.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/test.js
+++ b/test/test.js
@@ -43,7 +43,7 @@ describe('suitcss', function() {
         'minify',
         'use',
         'lint',
-        'postcss-import',
+        'postcss-easy-import',
         'postcss-reporter',
         'cssnano'
       ];
@@ -55,7 +55,7 @@ describe('suitcss', function() {
 
     it('should allow an import root to be set', function() {
       var opts = mergeOptions({root: 'test/root'});
-      expect(opts['postcss-import'].root).to.equal('test/root');
+      expect(opts['postcss-easy-import'].root).to.equal('test/root');
     });
 
     it('should allow stylelint to be enabled', function() {
@@ -76,7 +76,7 @@ describe('suitcss', function() {
       });
 
       expect(opts.use).to.eql([
-        'postcss-import',
+        'postcss-easy-import',
         'postcss-custom-properties',
         'postcss-calc',
         'postcss-custom-media',
@@ -84,7 +84,7 @@ describe('suitcss', function() {
         'postcss-reporter'
       ]);
       expect(opts.autoprefixer).to.eql(autoprefixer);
-      expect(opts['postcss-import'].root).to.equal('test/root');
+      expect(opts['postcss-easy-import'].root).to.equal('test/root');
     });
 
     describe('passing options to postcss', function() {
@@ -125,7 +125,7 @@ describe('suitcss', function() {
         });
 
         expect(opts.use).to.eql([
-          'postcss-import',
+          'postcss-easy-import',
           'postcss-custom-properties',
           'postcss-custom-media',
           'autoprefixer',
@@ -141,7 +141,7 @@ describe('suitcss', function() {
         });
 
         expect(opts.use).to.eql([
-          'postcss-import',
+          'postcss-easy-import',
           'postcss-custom-properties',
           'postcss-calc',
           'postcss-custom-media',


### PR DESCRIPTION
Fixes #28 

This is just a straight swap and introduces a few extra options like globbing.

@giuseppeg Thinking of publishing this as `2.0.0` as I kinda borked the upgrade of `stylelint-config` by only doing a patch release last time.