### PR TITLE
Remove beforeLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,10 +6,11 @@
     "comma-dangle": [2, "never"],
     "max-len": 0,
     "func-names": 0,
-    "one-var": [2, { uninitialized: "always", initialized: "never" }],
+    "one-var": [2, { "uninitialized": "always", "initialized": "never" }],
     "no-param-reassign": [0],
     "no-use-before-define": [2, "nofunc"],
     "space-before-function-paren": 0,
-    "object-curly-spacing": 0
+    "object-curly-spacing": 0,
+    "global-require": 0
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Remove `beforeLint` feature
 * Add default browsers list for autoprefixer
 * Use `stylelint-config-suitcss` from within the preprocessor. No longer needs
   to be installed locally by the consumer.

--- a/README.md
+++ b/README.md
@@ -126,24 +126,6 @@ locally in your package.
 
 If set to `true` then the output is minified by [`cssnano`](http://cssnano.co/).
 
-##### `beforeLint`
-
-* Type: `Function`
-* Default: `undefined`
-
-Called with the imported CSS before it's passed to `postcss-bem-linter`. This allows you to transform the CSS first and it must return the css string.
-
-Third paramater is the options object containing any PostCSS configuration you may need.
-
-```js
-{
-  beforeLint(css, filename, options) {
-    // Do something to the imported css
-    return css;
-  }
-}
-```
-
 ##### `postcss`
 
 * Type: `Object`
@@ -156,7 +138,6 @@ Options that are passed directly to `postcss`, as per [the documentation](https:
   postcss: {from: 'filename.css'}
 }
 ```
-
 
 ##### `use`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,3 @@
-/**
- * Module dependencies
- */
 var assign = require('object-assign-deep');
 var isEmpty = require('lodash.isempty');
 var difference = require('lodash.difference');
@@ -10,10 +7,6 @@ var cssnano = require('cssnano');
 var reporter = require('postcss-reporter');
 var stylelint = require('stylelint');
 var stylelintConfigSuit = require('stylelint-config-suitcss');
-
-/**
- * Module export
- */
 
 module.exports = preprocessor;
 
@@ -92,22 +85,15 @@ function preprocessor(css, options) {
 
 function mergeOptions(options) {
   options = options || {};
-
-  var merged = assign({}, defaults, options);
+  var mergedOpts = assign({}, defaults, options);
 
   // Set some core options
-  if (merged.root) {
-    merged['postcss-easy-import'].root = merged.root;
+  if (mergedOpts.root) {
+    mergedOpts['postcss-easy-import'].root = mergedOpts.root;
   }
 
-  // Call beforeLint function and pass processed css to bem-linter
-  var beforeLint = merged.beforeLint;
-  merged['postcss-easy-import'].transform = function(css, filename) {
-    if (typeof beforeLint === 'function') {
-      css = beforeLint(css, filename, merged);
-    }
-
-    return lintImportedFiles(merged, css, filename).then(function(result) {
+  mergedOpts['postcss-easy-import'].transform = function(css, filename) {
+    return lintImportedFiles(mergedOpts, css, filename).then(function(result) {
       return result.css;
     });
   };
@@ -115,11 +101,11 @@ function mergeOptions(options) {
   // Allow additional plugins to be merged with the defaults
   // but remove any duplicates so that it respects the new order
   if (!isEmpty(options.use)) {
-    var plugins = difference(merged.use, options.use);
-    merged.use = plugins.concat(options.use);
+    var plugins = difference(mergedOpts.use, options.use);
+    mergedOpts.use = plugins.concat(options.use);
   }
 
-  return merged;
+  return mergedOpts;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
-    "eslint": "^1.10.3",
-    "eslint-config-airbnb": "^5.0.0",
+    "eslint": "^3.5.0",
+    "eslint-config-airbnb": "^11.1.0",
     "mocha": "^2.3.4",
     "postcss-property-lookup": "^1.1.4",
     "rewire": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "npm run lint && mocha --reporter spec --slow 400 --timeout 8000",
+    "test": "npm run mocha && npm run lint",
+    "mocha": "mocha --reporter spec --slow 400 --timeout 8000",
     "lint": "eslint lib/index.js test/test.js bin/suitcss",
-    "watch": "mocha --watch --reporter spec --slow 400"
+    "watch": "npm run mocha -- --watch"
   },
   "keywords": [
     "css",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,12 +1,12 @@
 {
   "extends": "../.eslintrc",
-  "globals": {
-    "it": true,
-    "describe": true,
-    "afterEach": true,
-    "beforeEach": true
+  "env": {
+    "mocha": true
   },
   "rules": {
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "no-underscore-dangle": 0,
+    "consistent-return": 0,
+    "one-var-declaration-per-line": 0
   }
 }

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,8 +1,4 @@
 module.exports = {
-  beforeLint: function (css) {
-    console.log('beforeLint ran');
-    return css;
-  },
   use: [
     "postcss-property-lookup"
   ],

--- a/test/test.js
+++ b/test/test.js
@@ -197,77 +197,6 @@ describe('suitcss', function() {
         ).to.be.rejectedWith(Error, 'postcss-reporter: warnings or errors were found');
       });
     });
-
-    describe('transforming css before linting', function() {
-      describe('ensuring functions are called correctly', function() {
-        var lintImportedFilesStub, beforeLintStub, revert;
-
-        beforeEach(function() {
-          var postcssPromise = sinon.stub().resolves('/*linting done*/')();
-          lintImportedFilesStub = sinon.stub().returns(postcssPromise);
-          beforeLintStub = sinon.stub().returns('/*before lint*/');
-          revert = suitcss.__set__('lintImportedFiles', lintImportedFilesStub);
-        });
-
-        afterEach(function() {
-          revert();
-        });
-
-        it('should call `beforeLint` function before linting', function(done) {
-          suitcss(read('fixtures/component'), {
-            root: 'test/fixtures',
-            beforeLint: beforeLintStub
-          })
-          .then(function() {
-            expect(beforeLintStub).to.be.calledOnce;
-            expect(lintImportedFilesStub).to.be.calledOnce;
-            expect(beforeLintStub).to.have.been.calledBefore(lintImportedFilesStub);
-            done();
-          })
-          .catch(done);
-        });
-
-        it('should pass the result of `beforeLint` to `lintImportedFiles`', function(done) {
-          suitcss(read('fixtures/component'), {
-            root: 'test/fixtures',
-            beforeLint: beforeLintStub
-          })
-          .then(function() {
-            expect(lintImportedFilesStub.args[0][1]).to.equal('/*before lint*/');
-            done();
-          })
-          .catch(done);
-        });
-
-        it('should pass the options object to the beforeLint function as the third parameter', function(done) {
-          suitcss(read('fixtures/component'), {
-            root: 'test/fixtures',
-            beforeLint: beforeLintStub
-          })
-          .then(function() {
-            expect(beforeLintStub.args[0][2]).to.contain({root: 'test/fixtures'});
-            done();
-          })
-          .catch(done);
-        });
-      });
-
-      describe('outputting transformed css', function() {
-        it('should use the CSS returned from beforeLint', function(done) {
-          suitcss(read('fixtures/import'), {
-            root: 'test/fixtures',
-            beforeLint: function() {
-              return 'body {}';
-            }
-          })
-          .then(function(result) {
-            expect(result.css).to.equal('body {}\n');
-            done();
-          })
-          .catch(done);
-        });
-      });
-    });
   });
 });
 
@@ -338,7 +267,6 @@ describe('cli', function() {
     var testChild = exec('node bin/suitcss -c test/noautoprefixer.config.js', function(err, stdout) {
       if (err) return done(err);
       expect(stdout).to.equal(output);
-      expect(stdout).to.not.contain('beforeLint ran');
       done();
     });
 
@@ -350,18 +278,16 @@ describe('cli', function() {
     exec('node bin/suitcss -v  -c test/noautoprefixer.config.js test/fixtures/cli/input.css test/fixtures/cli/output.css', function(err, stdout) {
       if (err) return done(err);
       expect(stdout).to.contain('write');
-      expect(stdout).to.not.contain('beforeLint ran');
       done();
     });
   });
 
   it('should allow configurable import root', function(done) {
-    exec('node bin/suitcss -i test/fixtures -c test/noautoprefixer.config.js test/fixtures/import.css test/fixtures/cli/output.css', function(err, stdout) {
+    exec('node bin/suitcss -i test/fixtures -c test/noautoprefixer.config.js test/fixtures/import.css test/fixtures/cli/output.css', function(err) {
       if (err) return done(err);
       var res = read('fixtures/cli/output');
       var expected = read('fixtures/component.out');
       expect(res).to.equal(expected);
-      expect(stdout).to.not.contain('beforeLint ran');
       done();
     });
   });
@@ -375,22 +301,20 @@ describe('cli', function() {
   });
 
   it('should minify the output', function(done) {
-    exec('node bin/suitcss -i test/fixtures -c test/noautoprefixer.config.js test/fixtures/import.css test/fixtures/cli/output.css -m', function(err, stdout) {
+    exec('node bin/suitcss -i test/fixtures -c test/noautoprefixer.config.js test/fixtures/import.css test/fixtures/cli/output.css -m', function(err) {
       if (err) return done(err);
       var res = read('fixtures/cli/output');
       var expected = read('fixtures/minify.out');
-      expect(stdout).to.not.contain('beforeLint ran');
       expect(res).to.equal(expected);
       done();
     });
   });
 
   it('should allow a config file to be passed', function(done) {
-    exec('node bin/suitcss -i test/fixtures -c test/test.config.js test/fixtures/config.css test/fixtures/cli/output.css', function(err, stdout) {
+    exec('node bin/suitcss -i test/fixtures -c test/test.config.js test/fixtures/config.css test/fixtures/cli/output.css', function(err) {
       if (err) return done(err);
       var res = read('fixtures/cli/output');
       var expected = read('fixtures/config.out');
-      expect(stdout).to.contain('beforeLint ran');
       expect(res).to.equal(expected);
       done();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,9 @@ describe('suitcss', function() {
   });
 
   it('should handle invalid input', function() {
-    expect(function() {suitcss(null);}).to.throw(TypeError);
+    expect(function() {
+      suitcss(null);
+    }).to.throw(TypeError);
   });
 
   describe('using options', function() {


### PR DESCRIPTION
Fixes #35 

Also played around with a solution to #36 and it should be pretty easy, and also allow a `beforeLint` style feature anyway.