### PR TITLE
Allow input file to be linted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### HEAD
 
+* Input file is now linted (previously only imported files were passed through
+  the linting tools)
 * Add `--throw-error` (`-e`) to CLI
 * Enable `lint` option by default
 * Add `postcss-apply`

--- a/README.md
+++ b/README.md
@@ -75,15 +75,26 @@ Examples:
 Returns a [PostCSS promise](http://api.postcss.org/LazyResult.html)
 
 ```js
+preprocessor(css: String [, options: Object] [, filename: String]);
+```
+
+* `css`: CSS input (_required_)
+* `options`: Options to the preprocessor (see below) (_optional_)
+* `filename`: Filename of the input CSS file (_optional_)
+
+#### Example
+
+```js
 var preprocessor = require('suitcss-preprocessor');
 var fs = require('fs');
 
-var css = fs.readFileSync('src/components/index.css', 'utf8');
+var filename = 'src/components/index.css';
+var css = fs.readFileSync(filename, 'utf8');
 
 preprocessor(css, {
   root: 'path/to/css',
   minify: true,
-}).then(function(result) {
+}, filename).then(function(result) {
   fs.writeFileSync('build/bundle.css', result.css);
 });
 ```

--- a/bin/suitcss
+++ b/bin/suitcss
@@ -123,7 +123,7 @@ function run() {
       });
     }
 
-    suitcss(css, opts).then(function(result) {
+    suitcss(css, opts, input).then(function(result) {
       if (output) {
         writeFileSync(output, result.css + '\n');
       } else {

--- a/test/fixtures/component.css
+++ b/test/fixtures/component.css
@@ -1,7 +1,6 @@
 /** @define Component */
 
 @import "./util.css";
-
 @custom-media --media-query (min-width: 200px);
 
 :root {
@@ -12,17 +11,19 @@
 }
 
 .Component {
+  background: color(red a(90%));
   font-size: var(--Component-size);
   width: calc(100% * 1 / 6);
-  background: color(red a(90%));
 }
 
 .Component-item {
   display: flex;
+
   @apply --Component-color;
 }
 
 @media (--media-query) {
+
   .Component-item {
     color: red;
   }

--- a/test/fixtures/component.out.css
+++ b/test/fixtures/component.out.css
@@ -5,17 +5,19 @@
 }
 
 .Component {
+  background: rgba(255, 0, 0, 0.9);
   font-size: 16px;
   width: 16.66667%;
-  background: rgba(255, 0, 0, 0.9);
 }
 
 .Component-item {
   display: flex;
+
   color: green;
 }
 
 @media (min-width: 200px) {
+
   .Component-item {
     color: red;
   }

--- a/test/fixtures/config.out.css
+++ b/test/fixtures/config.out.css
@@ -5,17 +5,19 @@
 }
 
 .Component {
+  background: rgba(255, 0, 0, 0.9);
   font-size: 16px;
   width: 16.66667%;
-  background: rgba(255, 0, 0, 0.9);
 }
 
 .Component-item {
   display: flex;
+
   color: green;
 }
 
 @media (min-width: 200px) {
+
   .Component-item {
     color: red;
   }

--- a/test/fixtures/minify.out.css
+++ b/test/fixtures/minify.out.css
@@ -1,1 +1,1 @@
-.u-img{border-radius:50%}.Component{font-size:16px;width:16.66667%;background:rgba(255,0,0,.9)}.Component-item{display:flex;color:green}@media (min-width:200px){.Component-item{color:red}}
+.u-img{border-radius:50%}.Component{background:rgba(255,0,0,.9);font-size:16px;width:16.66667%}.Component-item{display:flex;color:green}@media (min-width:200px){.Component-item{color:red}}


### PR DESCRIPTION
Fixes #41

* Lint the input file
* Allow filename argument to `preprocessor` for better error reporting (otherwise it says `input 1.css`
* Pass `postcss` options to all processors. This makes it possible to have source maps on every file:

![screen shot 2016-09-27 at 13 52 08](https://cloud.githubusercontent.com/assets/360703/18873943/9d30b1d2-84b9-11e6-9772-6337c8a7b63a.png)

There is also quite a bit of noise in the test files as I had to disable linting on several tests to keep the test output sane (as it now tries to warn about all the example inputs).