### PR TITLE
Styles Encapsulation for Components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": "airbnb/legacy",
+  "env": {
+    "es6": true
+  },
   "globals": {
     "Promise": true
   },

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ node_js:
   - "4"
   - "5"
   - "6"
+addons:
+  apt:
+    packages:
+      - xvfb
+install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  - npm install

--- a/bin/suitcss
+++ b/bin/suitcss
@@ -20,6 +20,7 @@ program
   .usage('[<input>] [<output>]')
   .option('-c, --config [path]', 'a custom PostCSS config file')
   .option('-i, --import-root [path]', 'the root directory for imported css files')
+  .option('-s, --encapsulate', 'encapsulate component styles')
   .option('-w, --watch', 'watch the input file and any imports for changes')
   .option('-m, --minify', 'minify output with cssnano')
   .option('-e, --throw-error', 'throw an error when any warnings are found')
@@ -112,6 +113,7 @@ function run() {
     var opts = assign({}, config, {
       minify: program.minify,
       root: program.importRoot,
+      encapsulate: program.encapsulate,
       lint: program.lint
     });
 

--- a/lib/encapsulation.js
+++ b/lib/encapsulation.js
@@ -1,0 +1,128 @@
+/* eslint-disable quote-props */
+var autoreset = require('postcss-autoreset');
+
+var rules = {
+  inherited: {
+    'border-collapse': 'separate',
+    'border-spacing': 0,
+    'caption-side': 'top',
+    'color': 'initial',
+    'cursor': 'auto',
+    'direction': 'initial',
+    'empty-cells': 'show',
+    'font-size-adjust': 'none',
+    'font-family': 'initial',
+    'font-size': 'medium',
+    'font-style': 'normal',
+    'font-stretch': 'normal',
+    'font-variant': 'normal',
+    'font-weight': 'normal',
+    'font': 'initial',
+    'letter-spacing': 'normal',
+    'line-height': 'normal',
+    'list-style-image': 'none',
+    'list-style-position': 'outside',
+    'list-style-type': 'disc',
+    'list-style': 'initial',
+    'orphans': 2,
+    'quotes': 'initial',
+    'tab-size': 8,
+    'text-align': 'initial',
+    'text-align-last': 'auto',
+    'text-decoration-color': 'initial',
+    'text-indent': 0,
+    'text-justify': 'auto',
+    'text-shadow': 'none',
+    'text-transform': 'none',
+    'visibility': 'visible',
+    'white-space': 'normal',
+    'widows': 2,
+    'word-break': 'normal',
+    'word-spacing': 'normal',
+    'word-wrap': 'normal'
+  },
+  nonInherited: {
+    'animation': 'none 0s ease 0s 1 normal none running',
+    'backface-visibility': 'visible',
+    'background': 'transparent none repeat 0 0 / auto auto padding-box border-box scroll',
+    'border': 'medium none currentColor',
+    'border-image': 'none',
+    'border-radius': '0',
+    'bottom': 'auto',
+    'box-shadow': 'none',
+    'clear': 'none',
+    'clip': 'auto',
+    'columns': 'auto',
+    'column-count': 'auto',
+    'column-fill': 'balance',
+    'column-gap': 'normal',
+    'column-rule': 'medium none currentColor',
+    'column-span': '1',
+    'column-width': 'auto',
+    'content': 'normal',
+    'counter-increment': 'none',
+    'counter-reset': 'none',
+    'float': 'none',
+    'height': 'auto',
+    'hyphens': 'none',
+    'left': 'auto',
+    'margin': '0',
+    'max-height': 'none',
+    'max-width': 'none',
+    'min-height': '0',
+    'min-width': '0',
+    'opacity': '1',
+    'outline': 'medium none invert',
+    'overflow': 'visible',
+    'overflow-x': 'visible',
+    'overflow-y': 'visible',
+    'padding': '0',
+    'page-break-after': 'auto',
+    'page-break-before': 'auto',
+    'page-break-inside': 'auto',
+    'perspective': 'none',
+    'perspective-origin': '50% 50%',
+    'position': 'static',
+    'right': 'auto',
+    'table-layout': 'auto',
+    'text-decoration': 'none',
+    'top': 'auto',
+    'transform': 'none',
+    'transform-origin': '50% 50% 0',
+    'transform-style': 'flat',
+    'transition': 'none 0s ease 0s',
+    'unicode-bidi': 'normal',
+    'vertical-align': 'baseline',
+    'width': 'auto',
+    'z-index': 'auto'
+  }
+};
+
+// This applies only to the Component Root
+// to stop inheritance and ensure
+// styles encapsulation
+var resetInherited = autoreset({
+  reset: rules.inherited,
+  rulesMatcher: function (rule) {
+    var selector = rule.selector;
+    return (
+      selector.charAt(0) === '.' &&
+      /^\.(?:[a-z0-9]*-)?[A-Z](?:[a-zA-Z0-9]+)$/.test(selector)
+    );
+  }
+});
+
+resetInherited.postcssPlugin = 'autoreset-suitcss-encapsulation-inherited';
+
+// This applies to the Component Root and Descendants
+var resetGeneric = autoreset({
+  reset: rules.nonInherited,
+  rulesMatcher: 'suit'
+});
+
+resetGeneric.postcssPlugin = 'autoreset-suitcss-encapsulation-nonInherited';
+
+module.exports = {
+  resetInherited: resetInherited,
+  resetGeneric: resetGeneric
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pad-component": "0.0.1",
     "postcss": "^5.0.12",
     "postcss-apply": "^0.4.0",
+    "postcss-autoreset": "^1.2.0",
     "postcss-bem-linter": "^2.3.0",
     "postcss-calc": "^5.0.0",
     "postcss-color-function": "^2.0.1",
@@ -35,17 +36,24 @@
     "stylelint-config-suitcss": "^8.0.0"
   },
   "devDependencies": {
+    "browserify": "^13.1.0",
+    "browserify-css": "^0.9.2",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
+    "computed-style": "^0.3.0",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
     "mocha": "^2.3.4",
     "postcss-property-lookup": "^1.1.4",
     "rewire": "^2.5.1",
-    "sinon": "^1.17.2"
+    "sinon": "^1.17.2",
+    "tape": "^4.6.2",
+    "tape-css": "^1.0.2-beta",
+    "tape-run": "^2.1.4"
   },
   "scripts": {
-    "test": "npm run mocha && npm run lint",
+    "test": "npm run mocha && npm run test:encapsulation && npm run lint",
+    "test:encapsulation": "browserify -t [ browserify-css --autoInject=false ] test/encapsulation/browser.js | tape-run",
     "mocha": "mocha test/index.js --reporter spec --slow 400 --timeout 8000",
     "lint": "eslint lib/*.js test/**/*.js bin/suitcss",
     "watch": "npm run mocha -- --watch"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "test": "npm run mocha && npm run lint",
     "mocha": "mocha test/index.js --reporter spec --slow 400 --timeout 8000",
-    "lint": "eslint lib/index.js test/test.js bin/suitcss",
+    "lint": "eslint lib/*.js test/**/*.js bin/suitcss",
     "watch": "npm run mocha -- --watch"
   },
   "keywords": [

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -1,7 +1,7 @@
 module.exports = {
   lint: true,
   use: [
-    "postcss-property-lookup"
+    'postcss-property-lookup'
   ],
   autoprefixer: {
     add: false,

--- a/test/encapsulation/browser.js
+++ b/test/encapsulation/browser.js
@@ -1,0 +1,65 @@
+var getStyle = require('computed-style');
+var test = require('tape-css')(require('tape'));
+var styles = require('../fixtures/encapsulation.out.css');
+
+var dom = (function () {
+  var container = document.createElement('div');
+  container.innerHTML = `
+    <div class="Component" style="font-size: 30px">
+      <div class="Component-item">
+        <div class="Encapsulation" style="color: red">
+          <div class="Encapsulation-descendant">
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+  return container;
+}());
+
+test(
+  'Encapsulated Component\'s Root',
+  {
+    dom: dom,
+    styles: styles
+  },
+  function (is) {
+    var parent = dom.querySelector('.Component');
+    var root = dom.querySelector('.Encapsulation');
+    is.notEqual(
+      getStyle(root, 'font-size'),
+      getStyle(parent, 'font-size'),
+      'shouldn\'t inherit from the parent scope'
+    );
+
+    is.equal(
+      getStyle(root, 'width'),
+      '50px',
+      'can define own styles'
+    );
+    is.end();
+  }
+);
+
+test(
+  'Encapsulated Descendant',
+  {
+    dom: dom,
+    styles: styles
+  },
+  function (is) {
+    var descendant = dom.querySelector('.Encapsulation-descendant');
+    is.equal(
+      getStyle(descendant, 'color'),
+      'rgb(255, 0, 0)',
+      'should inherit from the Component scope'
+    );
+
+    is.equal(
+      getStyle(descendant, 'background-color'),
+      'rgb(238, 238, 238)',
+      'can define own styles'
+    );
+    is.end();
+  }
+);

--- a/test/encapsulation/index.js
+++ b/test/encapsulation/index.js
@@ -1,0 +1,61 @@
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var suitcss = require('../../lib');
+var util = require('../util');
+var expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+describe('encapsulation', function() {
+  it('should reset inherited and non inherited properties', function(done) {
+    var input = util.read('fixtures/encapsulation');
+    var output = util.read('fixtures/encapsulation.out');
+
+    suitcss(input, {
+      encapsulate: true,
+      root: 'test/fixtures',
+      lint: false,
+      // Set browsers to 'Chrome 50'
+      // for a predictable result
+      autoprefixer: {
+        browsers: 'Chrome 50'
+      }
+    }).then(function(result) {
+      expect(result.css.trim()).to.be.equal(output.trim());
+      done();
+    }).catch(done);
+  });
+
+  describe('plugins', function() {
+    function getPluginsNames(result) {
+      return (result.processor.plugins || []).map(function (plugin) {
+        return plugin.postcssPlugin;
+      });
+    }
+
+    it('should insert the encapsulationPlugins to the `plugins` array', function(done) {
+      suitcss('body {}', {
+        encapsulate: true,
+        lint: false
+      }).then(function (result) {
+        var plugins = getPluginsNames(result);
+        expect(plugins).to.include('autoreset-suitcss-encapsulation-inherited');
+        expect(plugins).to.include('autoreset-suitcss-encapsulation-nonInherited');
+        done();
+      }).catch(done);
+    });
+
+    it('should insert the encapsulationPlugins before `autoprefixer`', function(done) {
+      suitcss('body {}', {
+        encapsulate: true,
+        lint: false
+      }).then(function (result) {
+        var plugins = getPluginsNames(result);
+        var autoprefixerIndex = plugins.indexOf('autoprefixer');
+        expect(autoprefixerIndex).to.be.above(plugins.indexOf('autoreset-suitcss-encapsulation-inherited'));
+        expect(autoprefixerIndex).to.be.above(plugins.indexOf('autoreset-suitcss-encapsulation-nonInherited'));
+        done();
+      }).catch(done);
+    });
+  });
+});

--- a/test/fixtures/component.css
+++ b/test/fixtures/component.css
@@ -4,7 +4,7 @@
 @custom-media --media-query (min-width: 200px);
 
 :root {
-  --Component-size: 16px;
+  --Component-size: 26px;
   --Component-color: {
     color: green;
   };

--- a/test/fixtures/component.out.css
+++ b/test/fixtures/component.out.css
@@ -6,7 +6,7 @@
 
 .Component {
   background: rgba(255, 0, 0, 0.9);
-  font-size: 16px;
+  font-size: 26px;
   width: 16.66667%;
 }
 

--- a/test/fixtures/config.out.css
+++ b/test/fixtures/config.out.css
@@ -6,7 +6,7 @@
 
 .Component {
   background: rgba(255, 0, 0, 0.9);
-  font-size: 16px;
+  font-size: 26px;
   width: 16.66667%;
 }
 

--- a/test/fixtures/encapsulation.css
+++ b/test/fixtures/encapsulation.css
@@ -1,0 +1,28 @@
+@import './component';
+@import './util';
+
+.Encapsulation {
+  color: red;
+  width: 50px;
+}
+
+.Encapsulation-descendant {
+  background-color: #eee;
+}
+
+.Encapsulation-descendant:hover {
+  background-color: #f00;
+}
+
+.Encapsulation-descendant[aria-hidden="true"] {
+  display: none;
+}
+
+.Encapsulation.is-inState {
+  background-color: red;
+}
+
+.Encapsulation-item,
+.Encapsulation span {
+  filter: blur(10px);
+}

--- a/test/fixtures/encapsulation.out.css
+++ b/test/fixtures/encapsulation.out.css
@@ -1,0 +1,140 @@
+.Component,
+.Encapsulation {
+  border-collapse: separate;
+  border-spacing: 0;
+  caption-side: top;
+  color: initial;
+  cursor: auto;
+  direction: initial;
+  empty-cells: show;
+  font-size-adjust: none;
+  font-family: initial;
+  font-size: medium;
+  font-style: normal;
+  font-stretch: normal;
+  font-variant: normal;
+  font-weight: normal;
+  font: initial;
+  letter-spacing: normal;
+  line-height: normal;
+  list-style-image: none;
+  list-style-position: outside;
+  list-style-type: disc;
+  list-style: initial;
+  orphans: 2;
+  quotes: initial;
+  tab-size: 8;
+  text-align: initial;
+  text-align-last: auto;
+  -webkit-text-decoration-color: initial;
+          text-decoration-color: initial;
+  text-indent: 0;
+  text-justify: auto;
+  text-shadow: none;
+  text-transform: none;
+  visibility: visible;
+  white-space: normal;
+  widows: 2;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+}
+.Component,
+.Component-item,
+.Encapsulation,
+.Encapsulation-descendant {
+  animation: none 0s ease 0s 1 normal none running;
+  backface-visibility: visible;
+  background: transparent none repeat 0 0 / auto auto padding-box border-box scroll;
+  border: medium none currentColor;
+  border-image: none;
+  border-radius: 0;
+  bottom: auto;
+  box-shadow: none;
+  clear: none;
+  clip: auto;
+  columns: auto;
+  column-count: auto;
+  column-fill: balance;
+  column-gap: normal;
+  column-rule: medium none currentColor;
+  column-span: 1;
+  column-width: auto;
+  content: normal;
+  counter-increment: none;
+  counter-reset: none;
+  float: none;
+  height: auto;
+  hyphens: none;
+  left: auto;
+  margin: 0;
+  max-height: none;
+  max-width: none;
+  min-height: 0;
+  min-width: 0;
+  opacity: 1;
+  outline: medium none invert;
+  overflow: visible;
+  overflow-x: visible;
+  overflow-y: visible;
+  padding: 0;
+  page-break-after: auto;
+  page-break-before: auto;
+  page-break-inside: auto;
+  perspective: none;
+  perspective-origin: 50% 50%;
+  position: static;
+  right: auto;
+  table-layout: auto;
+  text-decoration: none;
+  top: auto;
+  transform: none;
+  transform-origin: 50% 50% 0;
+  transform-style: flat;
+  transition: none 0s ease 0s;
+  unicode-bidi: normal;
+  vertical-align: baseline;
+  width: auto;
+  z-index: auto;
+}
+/** @define Component */
+.Component {
+  background: rgba(255, 0, 0, 0.9);
+  font-size: 26px;
+  width: 16.66667%;
+}
+.Component-item {
+  display: flex;
+
+  color: green;
+}
+@media (min-width: 200px) {
+
+  .Component-item {
+    color: red;
+  }
+}
+.u-img {
+  border-radius: 50%;
+}
+.Encapsulation {
+  color: red;
+  width: 50px;
+}
+.Encapsulation-descendant {
+  background-color: #eee;
+}
+.Encapsulation-descendant:hover {
+  background-color: #f00;
+}
+.Encapsulation-descendant[aria-hidden="true"] {
+  display: none;
+}
+.Encapsulation.is-inState {
+  background-color: red;
+}
+.Encapsulation-item,
+.Encapsulation span {
+  -webkit-filter: blur(10px);
+          filter: blur(10px);
+}

--- a/test/fixtures/minify.out.css
+++ b/test/fixtures/minify.out.css
@@ -1,1 +1,1 @@
-.u-img{border-radius:50%}.Component{background:rgba(255,0,0,.9);font-size:16px;width:16.66667%}.Component-item{display:flex;color:green}@media (min-width:200px){.Component-item{color:red}}
+.u-img{border-radius:50%}.Component{background:rgba(255,0,0,.9);font-size:26px;width:16.66667%}.Component-item{display:flex;color:green}@media (min-width:200px){.Component-item{color:red}}

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
+require('./cli');
+require('./encapsulation');
+require('./linting');
 require('./node');
 require('./options');
-require('./cli');
-require('./linting');

--- a/test/node.js
+++ b/test/node.js
@@ -5,7 +5,9 @@ var expect = chai.expect;
 
 describe('node API', function() {
   it('should return a css string', function(done) {
-    suitcss('body {}', {lint: false}).then(function(result) {
+    suitcss('body {}', {
+      lint: false
+    }).then(function(result) {
       expect(result.css).to.be.a('string');
       done();
     });

--- a/test/options.js
+++ b/test/options.js
@@ -43,14 +43,11 @@ describe('basic options', function() {
     });
 
     expect(opts.use).to.eql([
-      'postcss-easy-import',
       'postcss-custom-properties',
       'postcss-calc',
       'postcss-color-function',
       'postcss-custom-media',
-      'postcss-apply',
-      'autoprefixer',
-      'postcss-reporter'
+      'postcss-apply'
     ]);
     expect(opts.autoprefixer).to.eql(autoprefixer);
     expect(opts['postcss-easy-import'].root).to.equal('test/root');
@@ -66,19 +63,16 @@ describe('re-ordering the `use` array of postcss plugins', function() {
 
   it('should allow reordering of use array and remove duplicates', function() {
     var opts = mergeOptions({
-      use: ['autoprefixer', 'postcss-at2x', 'postcss-calc', 'postcss-reporter']
+      use: ['postcss-at2x', 'postcss-calc']
     });
 
     expect(opts.use).to.eql([
-      'postcss-easy-import',
       'postcss-custom-properties',
       'postcss-color-function',
       'postcss-custom-media',
       'postcss-apply',
-      'autoprefixer',
       'postcss-at2x',
-      'postcss-calc',
-      'postcss-reporter'
+      'postcss-calc'
     ]);
   });
 
@@ -88,14 +82,11 @@ describe('re-ordering the `use` array of postcss plugins', function() {
     });
 
     expect(opts.use).to.eql([
-      'postcss-easy-import',
       'postcss-custom-properties',
       'postcss-calc',
       'postcss-color-function',
       'postcss-custom-media',
       'postcss-apply',
-      'autoprefixer',
-      'postcss-reporter',
       'postcss-at2x',
       'postcss-property-lookup'
     ]);


### PR DESCRIPTION
This branch adds a `encapsulateStyles` option that when enabled does the follow:

* resets all the inherited values for the component's root
* resets non-inherited values for the component's root and *descendants*