### PR TITLE
bump postcss-reporter to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-custom-media": "^5.0.0",
     "postcss-custom-properties": "^5.0.0",
     "postcss-easy-import": "^1.0.1",
-    "postcss-reporter": "^1.3.0",
+    "postcss-reporter": "^2.0.0",
     "read-file-stdin": "^0.2.1",
     "stylelint": "^7.2.0",
     "stylelint-config-suitcss": "^8.0.0"

--- a/test/fixtures/encapsulation.out.css
+++ b/test/fixtures/encapsulation.out.css
@@ -39,6 +39,7 @@
   word-spacing: normal;
   word-wrap: normal;
 }
+
 .Component,
 .Component-item,
 .Encapsulation,
@@ -97,42 +98,53 @@
   width: auto;
   z-index: auto;
 }
+
 /** @define Component */
+
+.u-img {
+  border-radius: 50%;
+}
+
 .Component {
   background: rgba(255, 0, 0, 0.9);
   font-size: 26px;
   width: 16.66667%;
 }
+
 .Component-item {
   display: flex;
 
   color: green;
 }
+
 @media (min-width: 200px) {
 
   .Component-item {
     color: red;
   }
 }
-.u-img {
-  border-radius: 50%;
-}
+
 .Encapsulation {
   color: red;
   width: 50px;
 }
+
 .Encapsulation-descendant {
   background-color: #eee;
 }
+
 .Encapsulation-descendant:hover {
   background-color: #f00;
 }
+
 .Encapsulation-descendant[aria-hidden="true"] {
   display: none;
 }
+
 .Encapsulation.is-inState {
   background-color: red;
 }
+
 .Encapsulation-item,
 .Encapsulation span {
   -webkit-filter: blur(10px);


### PR DESCRIPTION
this is in response to the issue reported here suitcss/stylelint-config-suitcss#24
where running `suitcss` resulted in lots of noisy "undefined [undefined]" output

the issue was related to message filtering in `postcss-reporter`
reported here TrySound/postcss-inline-svg#32
and then fixed here postcss/postcss-reporter#30

I've bumped the version and re-run my app and it cleared the issue and did not appear to introduce any new issues