### PR TITLE
Fix undefined cli flags override config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### HEAD
 
+### 3.0.1 (November XX, 2016)
+
+* Fix: `undefined` cli flags don't override config
+
 ### 3.0.0 (October 20, 2016)
 
 * Pin core plugins order:

--- a/bin/suitcss
+++ b/bin/suitcss
@@ -110,12 +110,18 @@ function run() {
   read(input, function(err, buffer) {
     if (err) logger.throw(err);
     var css = buffer.toString();
-    var opts = assign({}, config, {
-      minify: program.minify,
-      root: program.importRoot,
-      encapsulate: program.encapsulate,
-      lint: program.lint
-    });
+    var flags = [
+      'minify',
+      'encapsulate',
+      'root',
+      'lint'
+    ].reduce(function (accumulator, flag) {
+      if (({}).hasOwnProperty.call(program, flag)) {
+        accumulator[flag] = program[flag];
+      }
+      return accumulator;
+    }, {});
+    var opts = assign({}, config, flags);
 
     if (program.throwError) {
       assign(opts, {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-custom-media": "^5.0.0",
     "postcss-custom-properties": "^5.0.0",
     "postcss-easy-import": "^1.0.1",
-    "postcss-reporter": "^1.3.0",
+    "postcss-reporter": "^2.0.0",
     "read-file-stdin": "^0.2.1",
     "stylelint": "^7.2.0",
     "stylelint-config-suitcss": "^8.0.0"

--- a/test/cli.js
+++ b/test/cli.js
@@ -87,11 +87,21 @@ describe('cli', function() {
   });
 
   it('should allow to override config options via cli flags', function(done) {
-    exec('node bin/suitcss -L -c test/config/test.js test/fixtures/import.css test/fixtures/cli/output.css', function(err) {
+    exec('node bin/suitcss -m -c test/config/test.js test/fixtures/import.css test/fixtures/cli/output.css', function(err) {
       if (err) return done(err);
       var res = util.read('fixtures/cli/output');
       var commentsPattern = /\/\*[^]*?\*\//g;
-      expect(res).to.match(commentsPattern);
+      expect(res).to.not.match(commentsPattern);
+      done();
+    });
+  });
+
+  it('should preserve config options when not passing cli flags', function(done) {
+    exec('node bin/suitcss -c test/config/cli-undefined-flags.js test/fixtures/import.css test/fixtures/cli/output.css', function(err) {
+      if (err) return done(err);
+      var res = util.read('fixtures/cli/output');
+      var commentsPattern = /\/\*[^]*?\*\//g;
+      expect(res).to.not.match(commentsPattern);
       done();
     });
   });

--- a/test/config/cli-undefined-flags.js
+++ b/test/config/cli-undefined-flags.js
@@ -1,0 +1,3 @@
+module.exports = {
+  minify: true
+};

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -1,5 +1,6 @@
 module.exports = {
   lint: true,
+  minify: false,
   use: [
     'postcss-property-lookup'
   ],


### PR DESCRIPTION
When cli flags are not passed their value is `undefined` and they override the config file options.
This branch fixes this behaviour.

Fixes #54 