### PR TITLE
Allow --importRoot to override root config option

### DIFF
--- a/bin/suitcss
+++ b/bin/suitcss
@@ -117,16 +117,20 @@ function run() {
   read(input, function(err, buffer) {
     if (err) logger.throw(err);
     var css = buffer.toString();
+    var optsAliases = {
+      importRoot: 'root'
+    };
     var flags = [
       'minify',
       'encapsulate',
-      'root',
+      'importRoot',
       'lint'
-    ].reduce(function (accumulator, flag) {
-      if (({}).hasOwnProperty.call(program, flag)) {
-        accumulator[flag] = program[flag];
+    ].reduce(function(acc, inFlag) {
+      if (({}).hasOwnProperty.call(program, inFlag)) {
+        var flag = optsAliases[inFlag] || inFlag;
+        acc[flag] = program[inFlag];
       }
-      return accumulator;
+      return acc;
     }, {});
     var opts = assign({}, config, flags);
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -133,5 +133,20 @@ describe('cli', function() {
       done();
     });
   });
-});
 
+  describe('--importRoot', function() {
+    it('should be able to override root in a config file with importRoot', function(done) {
+      exec('node bin/suitcss -c test/config/root-fake.js -i ./test/fixtures ./test/fixtures/import.css test/fixtures/cli/output.css', function(err) {
+        expect(err).to.be.null;
+        done();
+      });
+    });
+
+    it('should use the config root option if importRoot is undefined', function(done) {
+      exec('node bin/suitcss -c test/config/root-real.js ./test/fixtures/import.css test/fixtures/cli/output.css', function(err) {
+        expect(err).to.be.null;
+        done();
+      });
+    });
+  });
+});

--- a/test/config/root-fake.js
+++ b/test/config/root-fake.js
@@ -1,0 +1,3 @@
+module.exports = {
+  root: './foo/bar'
+};

--- a/test/config/root-real.js
+++ b/test/config/root-real.js
@@ -1,0 +1,3 @@
+module.exports = {
+  root: './test/fixtures'
+};


### PR DESCRIPTION
This depends on the fix in #69 before the tests will pass. We could probably add a test for @casio's work in the same `describe`.

cc @giuseppeg 